### PR TITLE
Added --exclude-filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ php artisan queue:failed:batch-retry --filter="PublishDocumentJob"
 php artisan queue:failed:batch-retry --filter="12234"
 ```
 
+**--exclude-filter**
+
+This is exact same as --filter, except in reverse. It will search all the payloads and exclude those given in the parameter.
+
+```console
+php artisan queue:failed:batch-retry --exclude-filter="PublishDocumentJob"
+```
+
 **--filter-by-exception**
 
 Same as the `--filter` option, but for the `exception` column in the `failed_jobs` table. Using this option, depending on how many records you have, could be very slow since it will have to do a full table scan to find results.

--- a/src/Commands/BatchRetryCommand.php
+++ b/src/Commands/BatchRetryCommand.php
@@ -19,6 +19,7 @@ class BatchRetryCommand extends Command
         {--limit= : Limit the amount of jobs to retry}
         {--queue= : Only retry on a specific queue}
         {--filter= : Filter by a specific string. This will be a search in the payload of the job}
+        {--exclude-filter= : Filter by excluding a specific string. This will be a search in the payload of the job}
         {--filter-by-exception= : Filter by a specific string on the exception.}
         {--dry-run : Do a dry run of the batch retry to have an idea of the size of the batch}';
 
@@ -56,6 +57,9 @@ class BatchRetryCommand extends Command
             })
             ->when($this->option('filter'), function ($query) {
                 $query->where('payload', 'like', '%'.$this->option('filter').'%');
+            })
+            ->when($this->option('exclude-filter'), function ($query) {
+                $query->where('payload', 'not like', '%'.$this->option('exclude-filter').'%');
             })
             ->when($this->option('filter-by-exception'), function ($query) {
                 $query->where('exception', 'like', '%'.$this->option('filter-by-exception').'%');

--- a/tests/BatchRetryCommandTest.php
+++ b/tests/BatchRetryCommandTest.php
@@ -91,6 +91,25 @@ class BatchRetryCommandTest extends TestCase
     }
 
     /** @test */
+    public function it_can_batch_retry_using_excluded_search()
+    {
+        $someFailedJob = factory(FailedJob::class)->create([
+            'payload' => ['displayName' => 'App\Jobs\SomeJob']
+        ]);
+        $someOtherFailedJob = factory(FailedJob::class)->create([
+            'payload' => ['displayName' => 'App\Jobs\SomeOtherJob']
+        ]);
+
+        Artisan::call('queue:failed:batch-retry', [
+            '--exclude-filter' => 'SomeJob',
+        ]);
+
+        $this->assertEquals(1, DB::table('jobs')->count());
+        $this->assertNotNull($someFailedJob->fresh());
+        $this->assertNull($someOtherFailedJob->fresh());
+    }
+
+    /** @test */
     public function it_can_batch_retry_limiting_by_date()
     {
         $newJobs = factory(FailedJob::class, 5)->create(['failed_at' => now()]);


### PR DESCRIPTION
Hi,

We sometimes have a use case where you want to retry all jobs except a ones with a certain payload. So this --exclude-filter is just the exact opposite of --filter.